### PR TITLE
Add code to display colors on windows correctly

### DIFF
--- a/pdforce.py
+++ b/pdforce.py
@@ -146,6 +146,7 @@ def bruteforce_pdf(pdf_file_path: Path, wordlist: list) -> Union[str, None]:
 
 
 def run():
+    os.system("color")
     args = cli_arguments()
     print(f"{Color.EMPHASIS}{TITLE}{Color.END}".center(500))
     pdf_path = get_valid_path(file_path=Path(args.pdf), prompt_title="PATH TO PDF")


### PR DESCRIPTION
This pull request makes the ANSI escape sequence get processed correctly on Windows.
See [here](https://stackoverflow.com/questions/12492810/python-how-can-i-make-the-ansi-escape-codes-to-work-also-in-windows) for more details.